### PR TITLE
CPack Packages and Travis Deployment

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,64 @@
+language: cpp
+matrix:
+  include:
+  - os: linux
+    dist: trusty
+    sudo: false
+    compiler: gcc-7
+    addons:
+      apt:
+        sources:
+        - ubuntu-toolchain-r-test
+        packages:
+        - g++-7
+        - cmake
+        - zlib1g-dev
+        - libbz2-dev
+        - libboost-dev
+        - libgsl0-dev
+    before_install:
+    - "python3 --version || :"
+    - "python --version || :"
+    install: export CXX="g++-7"
+    env:
+    - LINK_TOOL="ldd"
+    - DEPLOY_PATTERN="PureCLIP-*-linux64-{static,dynamic}.tar.gz"
+  - os: osx
+    osx_image: xcode9.2
+    compiler: gcc-7
+    before_install:
+    - brew ls --versions
+    - brew cask uninstall oclint
+    - brew install gcc@7 gsl
+    - brew install python || brew upgrade python
+    - brew ls --versions
+    - softwareupdate -l
+    - "python3 --version || :"
+    - "python --version || :"
+    install: export CXX="g++-7"
+    env:
+    - LINK_TOOL="otool -L"
+    - DEPLOY_PATTERN="PureCLIP-*-mac64.tar.gz"
+script:
+- ./util/pkg_check.py .
+- mkdir -p build && cd build
+- cmake ../src -DCMAKE_BUILD_TYPE=Release
+- make VERBOSE=1
+- "./pureclip --version"
+- "./winextract --version"
+- cmake . -DPKG_BUILD=1 -DSTATIC_BUILD=0
+- make package
+- "$LINK_TOOL pureclip || :"
+- cmake . -DSTATIC_BUILD=1
+- make package
+- "$LINK_TOOL pureclip || :"
+- ls -l
+deploy:
+  skip_cleanup: true
+  provider: releases
+  api_key:
+    secure: KsnzYgrpXAdynrnKKRudMImej6vTrF8zR39tvwf+gNDlLFXFA11MtXb88ZeY6rlcB0629lqleZsWDV/mBL+PXoQP9n7lmDgLwEa0vph9KWL21gRS2/remeTe4wp/WFWfdq7l0zNGpKO6dBDuw9VYdA/Hipa7uN34cqBWM2sGegsLSRV1ztcnra+5y+lQRznr8p6johYDfBGGisef/6SXDISAiZRLwtiMWfcP0tdPHgZ2FvUZsl5iJY2IkQXLMSj5zgUOdWj8Gnl8yPEnrWMBBhvjXnG4hkWCvup3KF85ggBGZrik+YhyaXFyft/TadnmmhLeSS+x4j/EVaOHEIUytI0yLsGhhthuqR5fpTFWeRbDe40hF0jQwRbM4tTQvz9tdZk4MqnAgofccCxLgoGUnUy+5wUuDUiCjF7to0o08rPxxEZPjNxSDWxIA7lYk5RoCR6XVAlCsMkJpYM0NtyvNIQRGlqLCjJZVBZXQTMS/KMtUoZ9ahhCtdTfHqQnzv7sy0Ti+ZIUbFFefOUgHIM1FklPjgktZi762+18TvPeiCTcdoeSUKbBeTHUMO+UBJ6uywvtzJqZdDOGdnXFq/uaiiHxBiIIeF0fQ880KhtBHdbB7WqoZzOfqyYcJic+m7b/eOuPOdHgUt7gokQQSSw8bgaf6OyDTRmgY5cZbu03EVo=
+  file_glob: True
+  file: $DEPLOY_PATTERN
+  on:
+    tags: True

--- a/pkg/README
+++ b/pkg/README
@@ -1,0 +1,38 @@
+========================================================================
+PureCLIP 1.0.5
+Capturing target-specific protein-RNA interaction footprints
+
+(c) 2018 Sabrina Krakau, Max Planck Institute for Molecular Genetics
+Contact: krakau@molgen.mpg.de
+========================================================================
+
+PureCLIP is freely available and licensed under the GPLv3. A copy of the
+license is shipped with this binary.
+
+For more information and to obtain the source code please visit
+https://github.com/skrakau/PureCLIP
+
+== REQUIREMENTS ========================================================
+
+- Linux static build
+  Statically linked, should work on most 64-bit systems
+
+- Linux dynamic build
+  Dynamically linked, requires the following dependencies to be
+  installed on the system:
+    GSL (1.16)
+    zlib1g (1.2.8)
+    openMP (libgomp1 4.9.2)
+
+- Mac OS build
+  Statically linked against libstdc++, gsl and libz. Should work on
+  Mac OS 10.11 and newer.
+
+
+== USAGE ===============================================================
+
+For information on how to use pureclip, invoke pureclip with
+
+    pureclip -h
+
+and consult the online documentation available under the URL above.

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -37,13 +37,21 @@ add_definitions (${SEQAN_DEFINITIONS})
 # Add CXX flags found by find_package (SeqAn).
 set (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${SEQAN_CXX_FLAGS} ${OpenMP_CXX_FLAGS}")
 
-
 # PureCLIP static build for Linux
-if ( CMAKE_PURECLIP_LINUX_STATIC )
-    message ( STATUS "Configuring Linux static build" )
-    SET(CMAKE_FIND_LIBRARY_SUFFIXES ".a")
-    SET(BUILD_SHARED_LIBRARIES OFF)
-    SET(CMAKE_EXE_LINKER_FLAGS "-static -Wl,--whole-archive -lpthread -Wl,--no-whole-archive")
+set (LINK_TYPE "-dynamic")
+if ( STATIC_BUILD )
+    set (LINK_TYPE "-static")
+    if(UNIX AND NOT APPLE)
+        message ( STATUS "Configuring Linux static build" )
+        SET(CMAKE_FIND_LIBRARY_SUFFIXES ".a")
+        SET(CMAKE_EXE_LINKER_FLAGS "-static -Wl,--whole-archive -lpthread -Wl,--no-whole-archive")
+    elseif (UNIX AND APPLE)
+        set (LINK_TYPE "")
+        message ( STATUS "Configuring Mac build with static libstdc++" )
+        string (REPLACE "dylib" "a" GSL_LIBRARIES "${GSL_LIBRARIES}")
+        SET(CMAKE_EXE_LINKER_FLAGS "-static-libgcc -static-libstdc++")
+        SET(BUILD_SHARED_LIBRARIES OFF)
+    endif()
 endif()
 
 # Add executable and link against SeqAn dependencies.
@@ -60,3 +68,28 @@ add_executable (winextract winextract.cpp)
 
 target_link_libraries (pureclip ${Boost_LIBRARIES} ${SEQAN_LIBRARIES} ${GSL_LIBRARIES})
 target_link_libraries (winextract ${Boost_LIBRARIES} ${SEQAN_LIBRARIES} ${GSL_LIBRARIES})
+
+# Installation
+if ( PKG_BUILD )
+    SET ( BINDIR "." )
+    SET ( EXTRADIR "." )
+else()
+    SET ( BINDIR "bin" )
+    SET ( EXTRADIR "share/pureclip" )
+endif()
+install (TARGETS pureclip winextract RUNTIME DESTINATION "${BINDIR}")
+install (FILES "../LICENSE.md" DESTINATION "${EXTRADIR}")
+
+# Packaging
+if(UNIX AND NOT APPLE)
+    SET(CPACK_SYSTEM_NAME "linux64${LINK_TYPE}")
+elseif (UNIX AND APPLE)
+    SET(CPACK_SYSTEM_NAME "mac64${LINK_TYPE}")
+endif()
+SET(CPACK_PACKAGE_VERSION_MAJOR "1")
+SET(CPACK_PACKAGE_VERSION_MINOR "0")
+SET(CPACK_PACKAGE_VERSION_PATCH "5")
+SET(CPACK_GENERATOR "TGZ")
+SET(CPACK_INSTALLED_DIRECTORIES "${CMAKE_CURRENT_SOURCE_DIR}/../util;util" "${CMAKE_CURRENT_SOURCE_DIR}/../pkg;.")
+message(STATUS "Adding file ${CMAKE_CURRENT_SOURCE_DIR}/../pkg/README")
+include ( CPack )

--- a/util/pkg_check.py
+++ b/util/pkg_check.py
@@ -1,0 +1,88 @@
+#!/usr/bin/env python3
+
+import argparse
+import re
+import datetime
+import sys
+
+parser = argparse.ArgumentParser()
+parser.add_argument('path', metavar = "<repository root>", help = "Path to PureCLIP repository root")
+args = parser.parse_args()
+
+def seqan_argparse_version():
+    with open(args.path + '/src/pureclip.cpp') as pcpp:
+        for line in pcpp:
+            if re.match('.*setVersion\(parser,\s*"[.\d]+".*', line):
+                return(line.split('"')[1].rstrip())
+    raise Exception('Cannot detect pureclip version configuration of SeqAn argument parser')
+
+def readme_version():
+    with open(args.path + '/pkg/README') as readme:
+        for line in readme:
+            if re.match('^PureCLIP \d+[.]\d+[.]\d+$', line):
+                return(line.split(' ')[1].rstrip())
+    raise Exception('Cannot detect pureclip version configuration of README')
+
+def readme_year():
+    with open(args.path + '/pkg/README') as readme:
+        for line in readme:
+            if re.match('^\([cC]\) 20\d\d .*$', line):
+                return(int(line.split(' ')[1].rstrip()))
+    raise Exception('Cannot detect copyright year from README')
+
+def cpack_version():
+    major = None
+    minor = None
+    patch = None
+    try:
+        with open(args.path + '/src/CMakeLists.txt') as cmakelists:
+            for line in cmakelists:
+                if re.match('^(set|SET|Set)\(CPACK_PACKAGE_VERSION_MAJOR', line):
+                    major = int(line.split('"')[1].rstrip())
+                elif re.match('^(set|SET|Set)\(CPACK_PACKAGE_VERSION_MINOR', line):
+                    minor = int(line.split('"')[1].rstrip())
+                elif re.match('^(set|SET|Set)\(CPACK_PACKAGE_VERSION_PATCH', line):
+                    patch = int(line.split('"')[1].rstrip())
+        if all([ x != None for x in [major, minor, patch] ]):
+            return(str(major) + '.' + str(minor) + '.' + str(patch))
+    except ValueError:
+        raise Exception('Cannot detect pureclip version configuration of CPack (ValueError)')
+    raise Exception('Cannot detect pureclip version configuration of CPack')
+
+####################################################################################################
+
+
+try:
+    success = True
+    # Version Check
+    versions = {
+            'pureclip.cpp': seqan_argparse_version(),
+            'README' : readme_version(),
+            'CMakeLists.txt' : cpack_version()
+            }
+    if all([ v == versions['pureclip.cpp'] for v in versions.values()]):
+        print("[OK] All files report version " + versions['pureclip.cpp'])
+    else:
+        print("[ERR] Ambiguous versions reported. " + format(versions), file = sys.stderr)
+        success = False
+
+    # Copyright Year Check
+    cur_year = datetime.datetime.now().year
+    if cur_year == readme_year():
+        print("[OK] README copyright note contains current year " + str(cur_year))
+    else:
+        print("[ERR] README copyright note does not contain current year " + str(cur_year) + " but " + str(readme_year()), file = sys.stderr)
+        success = False
+
+    if success:
+        sys.exit(0)
+    else:
+        sys.exit(1)
+
+except Exception as err:
+    print("[ERR] Package Sanity Check failed:\n" + format(err))
+    sys.exit(1)
+
+
+
+


### PR DESCRIPTION
This patch
* Adds `README` file from binary releases to the repository for packaging
* Adds `pkg_check.py` script to check files for consistency before releases
* Updates `src/CMakeLists.txt` to add package targets via CPack
* Adds Travis configuration for automated Linux and Mac builds and automated release deployment 