### PR TITLE
Fix boost download link and also replace MD5 with SHA256

### DIFF
--- a/src/cmake/Boost.cmake
+++ b/src/cmake/Boost.cmake
@@ -1,8 +1,8 @@
 find_package ( Boost 1.58 )
 
 if (NOT Boost_FOUND )
-	set ( BOOST_URL "https://dl.bintray.com/boostorg/release/1.64.0/source/boost_1_64_0.tar.bz2")
-	set ( BOOST_MD5 "93eecce2abed9d2442c9676914709349")
+	set ( BOOST_URL "https://boostorg.jfrog.io/artifactory/main/release/1.64.0/source/boost_1_64_0.tar.bz2")
+  set ( BOOST_SHA256 "7bcc5caace97baa948931d712ea5f37038dbb1c5d89b43ad4def4ed7cb683332")
 	set ( BOOST_ZIP_OUT ${CMAKE_CURRENT_BINARY_DIR}/boost_1_64_0.tar.bz2 )
 	set ( BOOST_ROOT ${CMAKE_CURRENT_BINARY_DIR}/boost_1_64_0 )
 
@@ -10,7 +10,7 @@ if (NOT Boost_FOUND )
 		# Download zip file
 		message ("Downloading ${BOOST_URL}")
 		file (DOWNLOAD ${BOOST_URL} ${BOOST_ZIP_OUT}
-			EXPECTED_MD5 ${BOOST_MD5}
+      EXPECTED_SHA256 ${BOOST_SHA256}
 			SHOW_PROGRESS STATUS status)
 		list ( GET status 0 ret )
 		list ( GET status 0 str)

--- a/src/cmake/Boost.cmake
+++ b/src/cmake/Boost.cmake
@@ -2,7 +2,7 @@ find_package ( Boost 1.58 )
 
 if (NOT Boost_FOUND )
 	set ( BOOST_URL "https://boostorg.jfrog.io/artifactory/main/release/1.64.0/source/boost_1_64_0.tar.bz2")
-  set ( BOOST_SHA256 "7bcc5caace97baa948931d712ea5f37038dbb1c5d89b43ad4def4ed7cb683332")
+	set ( BOOST_SHA256 "7bcc5caace97baa948931d712ea5f37038dbb1c5d89b43ad4def4ed7cb683332")
 	set ( BOOST_ZIP_OUT ${CMAKE_CURRENT_BINARY_DIR}/boost_1_64_0.tar.bz2 )
 	set ( BOOST_ROOT ${CMAKE_CURRENT_BINARY_DIR}/boost_1_64_0 )
 
@@ -10,7 +10,7 @@ if (NOT Boost_FOUND )
 		# Download zip file
 		message ("Downloading ${BOOST_URL}")
 		file (DOWNLOAD ${BOOST_URL} ${BOOST_ZIP_OUT}
-      EXPECTED_SHA256 ${BOOST_SHA256}
+			EXPECTED_SHA256 ${BOOST_SHA256}
 			SHOW_PROGRESS STATUS status)
 		list ( GET status 0 ret )
 		list ( GET status 0 str)


### PR DESCRIPTION
This is a fix for building from a fresh git clone.

When downloading releases, boost.org appears to send you to mirrors.  The "dl.bintray.com" mirror hard-coded in the source currently returns 403 Forbidden for the entire boost path now. Replacing with a fresh mirror from https://boost.org.  "jfrog.io".  Also took the opportunity to switch to SHA256, as the MD5 algorithm is now discouraged.

Note this equivalence:

```
% wget 'https://boostorg.jfrog.io/artifactory/main/release/1.64.0/source/boost_1_64_0.tar.bz2'
...
% md5sum boost_1_64_0.tar.bz2 
93eecce2abed9d2442c9676914709349  boost_1_64_0.tar.bz2
% sha256sum boost_1_64_0.tar.bz2 
7bcc5caace97baa948931d712ea5f37038dbb1c5d89b43ad4def4ed7cb683332  boost_1_64_0.tar.bz2
```